### PR TITLE
Add left transparent tool panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,4 +2,5 @@
   height: 100vh;
   width: 100vw;
   margin: 0;
+  position: relative;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import ThreeScene from './ThreeScene'
+import ToolPanel from './ToolPanel'
 import './App.css'
 
 export default function App() {
   return (
     <div className="app">
+      <ToolPanel />
       <ThreeScene />
     </div>
   )

--- a/src/ToolPanel.css
+++ b/src/ToolPanel.css
@@ -1,0 +1,12 @@
+.tool-panel {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100vh;
+  width: 80px;
+  background-color: rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 1rem;
+}

--- a/src/ToolPanel.tsx
+++ b/src/ToolPanel.tsx
@@ -1,0 +1,9 @@
+import './ToolPanel.css'
+
+export default function ToolPanel() {
+  return (
+    <div className="tool-panel">
+      {/* Buttons for instruments will be added here */}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `ToolPanel` component for future instrument buttons
- position tool panel absolutely on the left with translucent background
- make `App` layout relative and include the new panel

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68467ab9908c832f8ba91c98245baabe