### PR TITLE
Add plane creation button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,19 @@
+import { useState } from 'react'
 import ThreeScene from './ThreeScene'
 import ToolPanel from './ToolPanel'
 import './App.css'
 
 export default function App() {
+  const [planes, setPlanes] = useState<number[]>([])
+
+  const addPlane = () => {
+    setPlanes((prev) => [...prev, prev.length])
+  }
+
   return (
     <div className="app">
-      <ToolPanel />
-      <ThreeScene />
+      <ToolPanel onAddPlane={addPlane} />
+      <ThreeScene planes={planes} />
     </div>
   )
 }

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -1,6 +1,7 @@
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import type { JSX } from 'react'
+import { DoubleSide } from 'three'
 
 
 function Box(props: JSX.IntrinsicElements['mesh']) {
@@ -12,12 +13,27 @@ function Box(props: JSX.IntrinsicElements['mesh']) {
   )
 }
 
-export default function ThreeScene() {
+function Plane(props: JSX.IntrinsicElements['mesh']) {
+  return (
+    <mesh rotation={[-Math.PI / 2, 0, 0]} {...props}>
+      <planeGeometry args={[10, 10]} />
+      <meshStandardMaterial color="lightgray" side={DoubleSide} />
+    </mesh>
+  )
+}
+interface ThreeSceneProps {
+  planes: number[]
+}
+
+export default function ThreeScene({ planes }: ThreeSceneProps) {
   return (
     <Canvas style={{ height: '100vh', width: '100vw' }}>
       <ambientLight />
       <pointLight position={[10, 10, 10]} />
       <Box />
+      {planes.map((id) => (
+        <Plane key={id} position={[0, 0, 0]} />
+      ))}
       <OrbitControls />
     </Canvas>
   )

--- a/src/ToolPanel.tsx
+++ b/src/ToolPanel.tsx
@@ -1,9 +1,13 @@
 import './ToolPanel.css'
 
-export default function ToolPanel() {
+interface ToolPanelProps {
+  onAddPlane: () => void
+}
+
+export default function ToolPanel({ onAddPlane }: ToolPanelProps) {
   return (
     <div className="tool-panel">
-      {/* Buttons for instruments will be added here */}
+      <button onClick={onAddPlane}>Plane</button>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- add callback handling for a Plane button in tool panel
- manage plane objects in App state
- render new planes in ThreeScene

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68467beea260832f9dbc136693989a68