### PR TITLE
Enable object translation via TransformControls

### DIFF
--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -1,21 +1,34 @@
 import { Canvas } from '@react-three/fiber'
-import { OrbitControls } from '@react-three/drei'
+import { OrbitControls, TransformControls } from '@react-three/drei'
+import { useRef, useState } from 'react'
 import type { JSX } from 'react'
-import { DoubleSide } from 'three'
+import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
+import { DoubleSide, Object3D } from 'three'
 
 
-function Box(props: JSX.IntrinsicElements['mesh']) {
+function Box({ onSelect, ...props }: JSX.IntrinsicElements['mesh'] & { onSelect: (obj: Object3D) => void }) {
+  const ref = useRef<Object3D>(null!)
   return (
-    <mesh {...props}>
+    <mesh
+      ref={ref}
+      {...props}
+      onClick={() => onSelect(ref.current)}
+    >
       <boxGeometry args={[1, 1, 1]} />
       <meshStandardMaterial color="orange" />
     </mesh>
   )
 }
 
-function Plane(props: JSX.IntrinsicElements['mesh']) {
+function Plane({ onSelect, ...props }: JSX.IntrinsicElements['mesh'] & { onSelect: (obj: Object3D) => void }) {
+  const ref = useRef<Object3D>(null!)
   return (
-    <mesh rotation={[-Math.PI / 2, 0, 0]} {...props}>
+    <mesh
+      ref={ref}
+      rotation={[-Math.PI / 2, 0, 0]}
+      {...props}
+      onClick={() => onSelect(ref.current)}
+    >
       <planeGeometry args={[10, 10]} />
       <meshStandardMaterial color="lightgray" side={DoubleSide} />
     </mesh>
@@ -26,15 +39,33 @@ interface ThreeSceneProps {
 }
 
 export default function ThreeScene({ planes }: ThreeSceneProps) {
+  const [selected, setSelected] = useState<Object3D | null>(null)
+  const orbitRef = useRef<OrbitControlsImpl | null>(null)
+
   return (
-    <Canvas style={{ height: '100vh', width: '100vw' }}>
+    <Canvas
+      style={{ height: '100vh', width: '100vw' }}
+      onPointerMissed={() => setSelected(null)}
+    >
       <ambientLight />
       <pointLight position={[10, 10, 10]} />
-      <Box />
+      <Box onSelect={setSelected} />
       {planes.map((id) => (
-        <Plane key={id} position={[0, 0, 0]} />
+        <Plane key={id} position={[0, 0, 0]} onSelect={setSelected} />
       ))}
-      <OrbitControls />
+      {selected && (
+        <TransformControls
+          object={selected}
+          mode="translate"
+          onMouseDown={() => {
+            if (orbitRef.current) orbitRef.current.enabled = false
+          }}
+          onMouseUp={() => {
+            if (orbitRef.current) orbitRef.current.enabled = true
+          }}
+        />
+      )}
+      <OrbitControls ref={orbitRef} />
     </Canvas>
   )
 }

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -15,7 +15,7 @@ function Box({
   selectedObject: Object3D | null
 }) {
   const ref = useRef<Object3D>(null!)
-  const isSelected = selectedObject === ref.current
+  const isSelected = selectedObject != null && selectedObject === ref.current
   return (
     <mesh
       ref={ref}
@@ -44,7 +44,7 @@ function Plane({
   selectedObject: Object3D | null
 }) {
   const ref = useRef<Object3D>(null!)
-  const isSelected = selectedObject === ref.current
+  const isSelected = selectedObject != null && selectedObject === ref.current
   return (
     <mesh
       ref={ref}

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -17,7 +17,14 @@ function Box({
   const ref = useRef<Object3D>(null!)
   const isSelected = selectedObject === ref.current
   return (
-    <mesh ref={ref} {...props} onClick={() => onSelect(ref.current)}>
+    <mesh
+      ref={ref}
+      {...props}
+      onClick={(e) => {
+        e.stopPropagation()
+        onSelect(ref.current)
+      }}
+    >
       <boxGeometry args={[1, 1, 1]} />
       <meshStandardMaterial
         color={isSelected ? '#00008B' : 'orange'}
@@ -43,7 +50,10 @@ function Plane({
       ref={ref}
       rotation={[-Math.PI / 2, 0, 0]}
       {...props}
-      onClick={() => onSelect(ref.current)}
+      onClick={(e) => {
+        e.stopPropagation()
+        onSelect(ref.current)
+      }}
     >
       <planeGeometry args={[10, 10]} />
       <meshStandardMaterial

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -20,7 +20,7 @@ function Box({
     <mesh
       ref={ref}
       {...props}
-      onClick={(e) => {
+      onPointerDown={(e) => {
         e.stopPropagation()
         onSelect(ref.current)
       }}
@@ -50,7 +50,7 @@ function Plane({
       ref={ref}
       rotation={[-Math.PI / 2, 0, 0]}
       {...props}
-      onClick={(e) => {
+      onPointerDown={(e) => {
         e.stopPropagation()
         onSelect(ref.current)
       }}
@@ -93,6 +93,7 @@ export default function ThreeScene({ planes }: ThreeSceneProps) {
         e.preventDefault()
         setSelected(null)
       }}
+      onPointerMissed={() => setSelected(null)}
     >
       <ambientLight />
       <pointLight position={[10, 10, 10]} />

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -74,6 +74,11 @@ export default function ThreeScene({ planes }: ThreeSceneProps) {
   const orbitRef = useRef<OrbitControlsImpl | null>(null)
 
   useEffect(() => {
+    // ensure nothing is selected on initial mount
+    setSelected(null)
+  }, [])
+
+  useEffect(() => {
     function handleKey(event: KeyboardEvent) {
       if (event.key === 'Escape') setSelected(null)
     }

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -20,7 +20,7 @@ function Box({
     <mesh ref={ref} {...props} onClick={() => onSelect(ref.current)}>
       <boxGeometry args={[1, 1, 1]} />
       <meshStandardMaterial
-        color={isSelected ? 'darkblue' : 'orange'}
+        color={isSelected ? '#00008B' : 'orange'}
         transparent
         opacity={isSelected ? 0.8 : 1}
       />
@@ -47,7 +47,7 @@ function Plane({
     >
       <planeGeometry args={[10, 10]} />
       <meshStandardMaterial
-        color={isSelected ? 'darkblue' : 'lightgray'}
+        color={isSelected ? '#00008B' : 'lightgray'}
         side={DoubleSide}
         transparent
         opacity={isSelected ? 0.8 : 1}


### PR DESCRIPTION
## Summary
- add selection and axis movement support in `ThreeScene`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68468496d960832fae1324cf25018a47