### PR TITLE
Add line drawing tool

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,22 @@ export default function App() {
     normal: [number, number, number]
   }
 
+  interface LineData {
+    start: [number, number, number]
+    end: [number, number, number]
+  }
+
   const [points, setPoints] = useState<PointData[]>([])
-  const [mode, setMode] = useState<'select' | 'placePoint'>('select')
+  const [lines, setLines] = useState<LineData[]>([])
+  const [lineStart, setLineStart] = useState<[number, number, number] | null>(
+    null,
+  )
+  const [tempLineEnd, setTempLineEnd] = useState<[number, number, number] | null>(
+    null,
+  )
+  const [mode, setMode] = useState<'select' | 'placePoint' | 'placeLine'>(
+    'select',
+  )
   const [message, setMessage] = useState<string | null>(null)
 
   const addPlane = () => {
@@ -24,13 +38,36 @@ export default function App() {
     setMessage('Click on an object to place a point')
   }
 
+  const enableLineDrawing = () => {
+    setLineStart(null)
+    setTempLineEnd(null)
+    setMode('placeLine')
+    setMessage('Click to set start of line')
+  }
+
   const handlePointAdd = (point: PointData) => {
     setPoints((prev) => [...prev, point])
     setMessage('Point added')
   }
 
+  const handleLinePoint = (point: [number, number, number]) => {
+    if (!lineStart) {
+      setLineStart(point)
+      setTempLineEnd(point)
+      setMessage('Click to set end of line')
+    } else {
+      setLines((prev) => [...prev, { start: lineStart, end: point }])
+      setLineStart(null)
+      setTempLineEnd(null)
+      setMode('select')
+      setMessage('Line added')
+    }
+  }
+
   const cancelPointPlacement = () => {
     setMode('select')
+    setLineStart(null)
+    setTempLineEnd(null)
     setMessage(null)
   }
 
@@ -43,12 +80,20 @@ export default function App() {
 
   return (
     <div className="app">
-      <ToolPanel onAddPlane={addPlane} onPlacePoint={enablePointPlacement} />
+      <ToolPanel
+        onAddPlane={addPlane}
+        onPlacePoint={enablePointPlacement}
+        onDrawLine={enableLineDrawing}
+      />
       <ThreeScene
         planes={planes}
         points={points}
+        lines={lines}
+        tempLine={{ start: lineStart, end: tempLineEnd }}
         mode={mode}
         onAddPoint={handlePointAdd}
+        onAddLinePoint={handleLinePoint}
+        onUpdateTempLineEnd={setTempLineEnd}
         onCancelPointPlacement={cancelPointPlacement}
       />
       {message && <div className="message">{message}</div>}

--- a/src/ToolPanel.tsx
+++ b/src/ToolPanel.tsx
@@ -3,13 +3,19 @@ import './ToolPanel.css'
 interface ToolPanelProps {
   onAddPlane: () => void
   onPlacePoint: () => void
+  onDrawLine: () => void
 }
 
-export default function ToolPanel({ onAddPlane, onPlacePoint }: ToolPanelProps) {
+export default function ToolPanel({
+  onAddPlane,
+  onPlacePoint,
+  onDrawLine,
+}: ToolPanelProps) {
   return (
     <div className="tool-panel">
       <button onClick={onAddPlane}>Plane</button>
       <button onClick={onPlacePoint}>Point</button>
+      <button onClick={onDrawLine}>Line</button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- implement line drawing mode with start/end selection
- track temporary line preview that follows the mouse
- show completed lines in the scene
- expose `Line` tool button in the tool panel

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847d4c381f4832fb403ecb9e55c38d9