### PR TITLE
Add upload model tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@types/three": "^0.177.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "three": "^0.177.0"
+        "three": "^0.177.0",
+        "web-ifc-three": "^0.0.126"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -3568,6 +3569,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/web-ifc": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/web-ifc/-/web-ifc-0.0.39.tgz",
+      "integrity": "sha512-sg+DyxDiyXBqlXXbz+uSqw8IGX+mVvHmn2+hg6UXDvAcrzJJw8EI2H4ZzlxWxCqqdpGVeK0wCpdeQm43UCDbrA=="
+    },
+    "node_modules/web-ifc-three": {
+      "version": "0.0.126",
+      "resolved": "https://registry.npmjs.org/web-ifc-three/-/web-ifc-three-0.0.126.tgz",
+      "integrity": "sha512-P2/jcuSZvpLnGiLcd1H+8N01oWuyIjmU5zUy/rzx8HTrbJn7FCE6uC4SFJyYvmxwN6+uFCRmEvzHkfHrdJzpcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "three-mesh-bvh": "0.5.21",
+        "web-ifc": "^0.0.39"
+      },
+      "peerDependencies": {
+        "three": "^0.149.0"
+      }
+    },
+    "node_modules/web-ifc-three/node_modules/three-mesh-bvh": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.21.tgz",
+      "integrity": "sha512-TGXPk7YwtlU5rgQJYA25OT6yAdBMeekfC4BTkGNtTWA5glb2rmEpjxvhZncRQSl73QZir2LFOQT0FjfzgG55xw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.123.0"
       }
     },
     "node_modules/webgl-constants": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@react-three/fiber": "^9.1.2",
     "@react-three/drei": "^10.1.2",
+    "@react-three/fiber": "^9.1.2",
     "@types/three": "^0.177.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "three": "^0.177.0"
+    "three": "^0.177.0",
+    "web-ifc-three": "^0.0.126"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/ToolPanel.tsx
+++ b/src/ToolPanel.tsx
@@ -1,21 +1,45 @@
 import './ToolPanel.css'
+import { useRef } from 'react'
 
 interface ToolPanelProps {
   onAddPlane: () => void
   onPlacePoint: () => void
   onDrawLine: () => void
+  onUploadModel: (file: File) => void
 }
 
 export default function ToolPanel({
   onAddPlane,
   onPlacePoint,
   onDrawLine,
+  onUploadModel,
 }: ToolPanelProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
   return (
     <div className="tool-panel">
       <button onClick={onAddPlane}>Plane</button>
       <button onClick={onPlacePoint}>Point</button>
       <button onClick={onDrawLine}>Line</button>
+      <button
+        style={{ marginTop: 'auto', marginBottom: '1rem' }}
+        onClick={() => fileInputRef.current?.click()}
+      >
+        Upload model
+      </button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".gltf,.glb,.ifc"
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          const file = e.target.files?.[0]
+          if (file) {
+            onUploadModel(file)
+            e.target.value = ''
+          }
+        }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add upload model button in tool panel
- support loading GLTF/GLB and IFC models in the app
- render uploaded models in the 3D scene

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6847dd2e8398832fb9d0ecbbdafe597a