### PR TITLE
Add upload model tool with GLTF and IFC support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@types/three": "^0.177.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "three": "^0.177.0"
+        "three": "^0.177.0",
+        "web-ifc-three": "^0.0.126"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1384,6 +1385,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1976,6 +1978,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3568,6 +3571,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/web-ifc": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/web-ifc/-/web-ifc-0.0.39.tgz",
+      "integrity": "sha512-sg+DyxDiyXBqlXXbz+uSqw8IGX+mVvHmn2+hg6UXDvAcrzJJw8EI2H4ZzlxWxCqqdpGVeK0wCpdeQm43UCDbrA=="
+    },
+    "node_modules/web-ifc-three": {
+      "version": "0.0.126",
+      "resolved": "https://registry.npmjs.org/web-ifc-three/-/web-ifc-three-0.0.126.tgz",
+      "integrity": "sha512-P2/jcuSZvpLnGiLcd1H+8N01oWuyIjmU5zUy/rzx8HTrbJn7FCE6uC4SFJyYvmxwN6+uFCRmEvzHkfHrdJzpcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "three-mesh-bvh": "0.5.21",
+        "web-ifc": "^0.0.39"
+      },
+      "peerDependencies": {
+        "three": "^0.149.0"
+      }
+    },
+    "node_modules/web-ifc-three/node_modules/three-mesh-bvh": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.21.tgz",
+      "integrity": "sha512-TGXPk7YwtlU5rgQJYA25OT6yAdBMeekfC4BTkGNtTWA5glb2rmEpjxvhZncRQSl73QZir2LFOQT0FjfzgG55xw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.123.0"
       }
     },
     "node_modules/webgl-constants": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@types/three": "^0.177.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "three": "^0.177.0"
+    "three": "^0.177.0",
+    "web-ifc-three": "^0.0.126"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,26 @@ import { useEffect, useState } from 'react'
 import ThreeScene from './ThreeScene'
 import ToolPanel from './ToolPanel'
 import './App.css'
+import { GLTFLoader } from 'three-stdlib'
+import { IFCLoader } from 'web-ifc-three'
+import type { Object3D } from 'three'
+
+function useFileInput(callback: (file: File) => Promise<void> | void) {
+  const [input] = useState(() => {
+    const el = document.createElement('input')
+    el.type = 'file'
+    el.accept = '.gltf,.glb,.ifc'
+    el.style.display = 'none'
+    el.addEventListener('change', () => {
+      const file = el.files?.[0]
+      if (file) void callback(file)
+      el.value = ''
+    })
+    document.body.appendChild(el)
+    return el
+  })
+  return () => input.click()
+}
 
 export default function App() {
   const [planes, setPlanes] = useState<number[]>([])
@@ -22,6 +42,7 @@ export default function App() {
   }
 
   const [points, setPoints] = useState<PointData[]>([])
+  const [models, setModels] = useState<Object3D[]>([])
   const [lines, setLines] = useState<LineData[]>([])
   const [lineStart, setLineStart] = useState<LineEnd | null>(null)
   const [tempLineEnd, setTempLineEnd] = useState<LineEnd | null>(null)
@@ -45,6 +66,23 @@ export default function App() {
     setTempLineEnd(null)
     setMode('placeLine')
     setMessage('Click to set start of line')
+  }
+
+  const loadModel = async (file: File) => {
+    if (file.name.toLowerCase().endsWith('.gltf') || file.name.toLowerCase().endsWith('.glb')) {
+      const loader = new GLTFLoader()
+      const arrayBuffer = await file.arrayBuffer()
+      const gltf = await loader.parseAsync(arrayBuffer, '')
+      setModels((prev) => [...prev, gltf.scene])
+      setMessage('Model added')
+    } else if (file.name.toLowerCase().endsWith('.ifc')) {
+      const loader = new IFCLoader()
+      void loader.ifcManager.setWasmPath('/')
+      const arrayBuffer = await file.arrayBuffer()
+      const model = await loader.parse(arrayBuffer)
+      setModels((prev) => [...prev, model])
+      setMessage('Model added')
+    }
   }
 
   const handlePointAdd = (point: PointData) => {
@@ -73,6 +111,8 @@ export default function App() {
     setMessage(null)
   }
 
+  const triggerFileInput = useFileInput(loadModel)
+
   useEffect(() => {
     if (message) {
       const id = setTimeout(() => setMessage(null), 2000)
@@ -86,11 +126,13 @@ export default function App() {
         onAddPlane={addPlane}
         onPlacePoint={enablePointPlacement}
         onDrawLine={enableLineDrawing}
+        onUploadModel={triggerFileInput}
       />
       <ThreeScene
         planes={planes}
         points={points}
         lines={lines}
+        models={models}
         tempLine={{ start: lineStart, end: tempLineEnd }}
         mode={mode}
         onAddPoint={handlePointAdd}

--- a/src/ToolPanel.css
+++ b/src/ToolPanel.css
@@ -11,3 +11,7 @@
   align-items: center;
   padding-top: 1rem;
 }
+
+.upload-button {
+  margin-top: auto;
+}

--- a/src/ToolPanel.tsx
+++ b/src/ToolPanel.tsx
@@ -4,18 +4,21 @@ interface ToolPanelProps {
   onAddPlane: () => void
   onPlacePoint: () => void
   onDrawLine: () => void
+  onUploadModel: () => void
 }
 
 export default function ToolPanel({
   onAddPlane,
   onPlacePoint,
   onDrawLine,
+  onUploadModel,
 }: ToolPanelProps) {
   return (
     <div className="tool-panel">
       <button onClick={onAddPlane}>Plane</button>
       <button onClick={onPlacePoint}>Point</button>
       <button onClick={onDrawLine}>Line</button>
+      <button className="upload-button" onClick={onUploadModel}>Upload model</button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add `web-ifc-three` dependency
- allow uploading of GLTF/IFC files via new ToolPanel button
- load GLTF with `GLTFLoader` and IFC with `IFCLoader`
- render uploaded models in `ThreeScene`
- style upload button to appear at bottom of tool panel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848603ea828832fadfd9c16d00c037c