### PR TITLE
Add sliding tool panel

### DIFF
--- a/src/ToolPanel.css
+++ b/src/ToolPanel.css
@@ -1,10 +1,15 @@
 .tool-panel-container {
   position: absolute;
-  left: 0;
+  left: -80px;
   top: 0;
   height: 100vh;
   width: 80px;
   z-index: 10;
+  transition: left 0.3s ease;
+}
+
+.tool-panel-container.open {
+  left: 0;
 }
 
 .tool-panel {
@@ -18,19 +23,13 @@
   flex-direction: column;
   align-items: center;
   padding-top: 1rem;
-  transform: translateX(-100%);
-  transition: transform 0.3s ease;
-}
-
-.tool-panel.open {
-  transform: translateX(0);
 }
 
 .panel-toggle {
   position: absolute;
   top: 50%;
-  left: 0;
-  transform: translate(-100%, -50%);
+  left: 100%;
+  transform: translate(0, -50%);
   width: 24px;
   height: 48px;
   background-color: rgba(0, 0, 0, 0.3);
@@ -38,9 +37,4 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-}
-
-.panel-toggle.open {
-  left: 80px;
-  transform: translate(0, -50%);
 }

--- a/src/ToolPanel.tsx
+++ b/src/ToolPanel.tsx
@@ -15,14 +15,14 @@ export default function ToolPanel({
   const [open, setOpen] = useState(false)
 
   return (
-    <div className="tool-panel-container">
-      <div className={`tool-panel${open ? ' open' : ''}`}>
+    <div className={`tool-panel-container${open ? ' open' : ''}`}>
+      <div className="tool-panel">
         <button onClick={onAddPlane}>Plane</button>
         <button onClick={onPlacePoint}>Point</button>
         <button onClick={onDrawLine}>Line</button>
       </div>
       <div
-        className={`panel-toggle${open ? ' open' : ''}`}
+        className="panel-toggle"
         onClick={() => setOpen(!open)}
       >
         {open ? '◀' : '▶'}


### PR DESCRIPTION
## Summary
- toggle tool panel with slide-in animation
- style the panel toggle and sliding behavior

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68489008c928832fa4f19066665a1785