### PR TITLE
Add persistent drawing modes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,16 +43,30 @@ export default function App() {
     setMode('idle')
   }
 
-  const enablePointPlacement = () => {
-    setMode('placePoint')
-    setMessage('Click on an object to place a point')
-  }
-
-  const enableLineDrawing = () => {
+  const togglePointPlacement = () => {
     setLineStart(null)
     setTempLineEnd(null)
-    setMode('placeLine')
-    setMessage('Click to set start of line')
+    setMode((prev) => {
+      if (prev === 'placePoint') {
+        setMessage(null)
+        return 'idle'
+      }
+      setMessage('Click on an object to place a point')
+      return 'placePoint'
+    })
+  }
+
+  const toggleLineDrawing = () => {
+    setLineStart(null)
+    setTempLineEnd(null)
+    setMode((prev) => {
+      if (prev === 'placeLine') {
+        setMessage(null)
+        return 'idle'
+      }
+      setMessage('Click to set start of line')
+      return 'placeLine'
+    })
   }
 
   const handlePointAdd = (point: PointData) => {
@@ -67,10 +81,9 @@ export default function App() {
       setMessage('Click to set end of line')
     } else {
       setLines((prev) => [...prev, { start: lineStart, end: point }])
-      setLineStart(null)
-      setTempLineEnd(null)
-      setMode('idle')
-      setMessage('Line added')
+      setLineStart(point)
+      setTempLineEnd(point)
+      setMessage('Click to set end of line')
     }
   }
 
@@ -79,6 +92,14 @@ export default function App() {
     setLineStart(null)
     setTempLineEnd(null)
     setMessage(null)
+  }
+
+  const cancelLineChain = () => {
+    setLineStart(null)
+    setTempLineEnd(null)
+    if (mode === 'placeLine') {
+      setMessage('Click to set start of line')
+    }
   }
 
   useEffect(() => {
@@ -92,8 +113,10 @@ export default function App() {
     <div className="app">
       <ToolPanel
         onAddPlane={addPlane}
-        onPlacePoint={enablePointPlacement}
-        onDrawLine={enableLineDrawing}
+        pointEnabled={mode === 'placePoint'}
+        onTogglePoint={togglePointPlacement}
+        lineEnabled={mode === 'placeLine'}
+        onToggleLine={toggleLineDrawing}
         moveEnabled={mode === 'move'}
         onToggleMove={toggleMove}
       />
@@ -107,6 +130,7 @@ export default function App() {
         onAddLinePoint={handleLinePoint}
         onUpdateTempLineEnd={setTempLineEnd}
         onCancelPointPlacement={cancelPointPlacement}
+        onCancelLineChain={cancelLineChain}
         onCancelMove={cancelMove}
       />
       {message && <div className="message">{message}</div>}

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -227,6 +227,7 @@ interface ThreeSceneProps {
   onAddLinePoint: (point: LineEnd) => void
   onUpdateTempLineEnd: (point: LineEnd) => void
   onCancelPointPlacement: () => void
+  onCancelLineChain: () => void
   onCancelMove: () => void
 }
 
@@ -240,6 +241,7 @@ export default function ThreeScene({
   onAddLinePoint,
   onUpdateTempLineEnd,
   onCancelPointPlacement,
+  onCancelLineChain,
   onCancelMove,
 }: ThreeSceneProps) {
   const [selected, setSelected] = useState<Object3D | null>(null)
@@ -275,13 +277,11 @@ export default function ThreeScene({
       onContextMenu={(e) => {
         e.preventDefault()
         setSelected(null)
-        if (mode === 'placePoint' || mode === 'placeLine')
-          onCancelPointPlacement()
+        if (mode === 'placeLine') onCancelLineChain()
       }}
       onPointerMissed={() => {
         setSelected(null)
-        if (mode === 'placePoint' || mode === 'placeLine')
-          onCancelPointPlacement()
+        if (mode === 'placeLine') onCancelLineChain()
       }}
     >
       <ambientLight />

--- a/src/ToolPanel.tsx
+++ b/src/ToolPanel.tsx
@@ -3,16 +3,20 @@ import './ToolPanel.css'
 
 interface ToolPanelProps {
   onAddPlane: () => void
-  onPlacePoint: () => void
-  onDrawLine: () => void
+  pointEnabled: boolean
+  onTogglePoint: () => void
+  lineEnabled: boolean
+  onToggleLine: () => void
   moveEnabled: boolean
   onToggleMove: () => void
 }
 
 export default function ToolPanel({
   onAddPlane,
-  onPlacePoint,
-  onDrawLine,
+  pointEnabled,
+  onTogglePoint,
+  lineEnabled,
+  onToggleLine,
   moveEnabled,
   onToggleMove,
 }: ToolPanelProps) {
@@ -28,8 +32,18 @@ export default function ToolPanel({
           Move
         </button>
         <button onClick={onAddPlane}>Plane</button>
-        <button onClick={onPlacePoint}>Point</button>
-        <button onClick={onDrawLine}>Line</button>
+        <button
+          className={pointEnabled ? 'active' : ''}
+          onClick={onTogglePoint}
+        >
+          Point
+        </button>
+        <button
+          className={lineEnabled ? 'active' : ''}
+          onClick={onToggleLine}
+        >
+          Line
+        </button>
       </div>
       <div
         className="panel-toggle"


### PR DESCRIPTION
## Summary
- enable Point and Line toggling in the tool panel
- allow continuous point placement
- implement chained line drawing with right‑click to break the chain
- allow toggling modes off through the tool buttons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848a606344c832f80bcdddada0d65ce