### PR TITLE
Refactor geometry types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,11 @@
 import { useEffect, useState } from 'react'
 import ThreeScene from './ThreeScene'
 import ToolPanel from './ToolPanel'
+import type { LineData, LineEnd, PointData } from './types'
 import './App.css'
 
 export default function App() {
   const [planes, setPlanes] = useState<number[]>([])
-  interface PointData {
-    objectId: string
-    position: [number, number, number]
-    normal: [number, number, number]
-  }
-
-  interface LineEnd {
-    objectId: string
-    position: [number, number, number]
-  }
-
-  interface LineData {
-    start: LineEnd
-    end: LineEnd
-  }
 
   const [points, setPoints] = useState<PointData[]>([])
   const [lines, setLines] = useState<LineData[]>([])

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -5,6 +5,7 @@ import type { JSX } from 'react'
 import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
 import { DoubleSide, Object3D, Vector3, Quaternion } from 'three'
 import type { BufferGeometry, BufferAttribute } from 'three'
+import type { LineData, LineEnd, PointData } from './types'
 
 
 function Box({
@@ -151,21 +152,6 @@ function Plane({
       />
     </mesh>
   )
-}
-interface PointData {
-  objectId: string
-  position: [number, number, number]
-  normal: [number, number, number]
-}
-
-interface LineEnd {
-  objectId: string
-  position: [number, number, number]
-}
-
-interface LineData {
-  start: LineEnd
-  end: LineEnd
 }
 
 function PointObject({ point, objectMap }: { point: PointData; objectMap: React.MutableRefObject<Record<string, Object3D | null>> }) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,15 @@
+export interface PointData {
+  objectId: string
+  position: [number, number, number]
+  normal: [number, number, number]
+}
+
+export interface LineEnd {
+  objectId: string
+  position: [number, number, number]
+}
+
+export interface LineData {
+  start: LineEnd
+  end: LineEnd
+}


### PR DESCRIPTION
## Summary
- centralize geometry interfaces into `src/types.ts`
- update `App.tsx` and `ThreeScene.tsx` to use shared types

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848a888d020832fa8d3d360920a2703