### PR TITLE
Add header menu

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -16,3 +16,16 @@
   border-radius: 4px;
 }
 
+.header-menu {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0.5rem 0;
+  z-index: 20;
+}
+

--- a/src/App.css
+++ b/src/App.css
@@ -16,16 +16,4 @@
   border-radius: 4px;
 }
 
-.header-menu {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  background-color: rgba(0, 0, 0, 0.3);
-  display: flex;
-  justify-content: center;
-  gap: 1rem;
-  padding: 0.5rem 0;
-  z-index: 20;
-}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import ThreeScene from './ThreeScene'
 import ToolPanel from './ToolPanel'
+import HeaderMenu from './HeaderMenu'
 import type { LineData, LineEnd, PointData } from './types'
 import './App.css'
 
@@ -97,6 +98,7 @@ export default function App() {
 
   return (
     <div className="app">
+      <HeaderMenu />
       <ToolPanel
         onAddPlane={addPlane}
         pointEnabled={mode === 'placePoint'}

--- a/src/HeaderMenu.css
+++ b/src/HeaderMenu.css
@@ -1,0 +1,48 @@
+.header-menu {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 0;
+  z-index: 20;
+}
+
+.menu-toggle {
+  display: none;
+  margin-left: 1rem;
+  font-size: 1.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+}
+
+.menu-items {
+  display: flex;
+  gap: 1rem;
+}
+
+@media (max-width: 600px) {
+  .menu-toggle {
+    display: block;
+  }
+
+  .menu-items {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    width: 100%;
+    flex-direction: column;
+    background-color: rgba(0, 0, 0, 0.3);
+    padding: 0.5rem 0;
+  }
+
+  .menu-items.open {
+    display: flex;
+  }
+}

--- a/src/HeaderMenu.tsx
+++ b/src/HeaderMenu.tsx
@@ -1,13 +1,22 @@
-import './App.css'
+import { useState } from 'react'
+import './HeaderMenu.css'
 
 export default function HeaderMenu() {
+  const [open, setOpen] = useState(false)
+  const toggle = () => setOpen(!open)
+
   return (
     <header className="header-menu">
-      <button>Home</button>
-      <button>Services</button>
-      <button>Prices</button>
-      <button>Contacts</button>
-      <button>About</button>
+      <button className="menu-toggle" aria-label="Toggle menu" onClick={toggle}>
+        ☰
+      </button>
+      <nav className={`menu-items${open ? ' open' : ''}`} onClick={() => setOpen(false)}>
+        <button>Home</button>
+        <button>Services</button>
+        <button>Prices</button>
+        <button>Contacts</button>
+        <button>About</button>
+      </nav>
     </header>
   )
 }

--- a/src/HeaderMenu.tsx
+++ b/src/HeaderMenu.tsx
@@ -1,0 +1,13 @@
+import './App.css'
+
+export default function HeaderMenu() {
+  return (
+    <header className="header-menu">
+      <button>Home</button>
+      <button>Services</button>
+      <button>Prices</button>
+      <button>Contacts</button>
+      <button>About</button>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- create HeaderMenu component with navigation buttons
- style the header menu in `App.css`
- render header in `App` component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848af9cb324832f8f3b4660fa01caf9