### PR TITLE
Add overlay sections with header anchors

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,15 @@
 .app {
-  height: 100vh;
-  width: 100vw;
+  width: 100%;
+  min-height: 100vh;
   margin: 0;
   position: relative;
+}
+
+.menu-section {
+  position: relative;
+  z-index: 1;
+  min-height: 100vh;
+  padding-top: 4rem;
 }
 
 .message {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,16 +98,6 @@ export default function App() {
 
   return (
     <div className="app">
-      <HeaderMenu />
-      <ToolPanel
-        onAddPlane={addPlane}
-        pointEnabled={mode === 'placePoint'}
-        onTogglePoint={togglePointPlacement}
-        lineEnabled={mode === 'placeLine'}
-        onToggleLine={toggleLineDrawing}
-        moveEnabled={mode === 'move'}
-        onToggleMove={toggleMove}
-      />
       <ThreeScene
         planes={planes}
         points={points}
@@ -121,6 +111,31 @@ export default function App() {
         onCancelLineChain={cancelLineChain}
         onCancelMove={cancelMove}
       />
+      <HeaderMenu />
+      <ToolPanel
+        onAddPlane={addPlane}
+        pointEnabled={mode === 'placePoint'}
+        onTogglePoint={togglePointPlacement}
+        lineEnabled={mode === 'placeLine'}
+        onToggleLine={toggleLineDrawing}
+        moveEnabled={mode === 'move'}
+        onToggleMove={toggleMove}
+      />
+      <section id="home" className="menu-section">
+        <h2>Home</h2>
+      </section>
+      <section id="services" className="menu-section">
+        <h2>Services</h2>
+      </section>
+      <section id="prices" className="menu-section">
+        <h2>Prices</h2>
+      </section>
+      <section id="contacts" className="menu-section">
+        <h2>Contacts</h2>
+      </section>
+      <section id="about" className="menu-section">
+        <h2>About</h2>
+      </section>
       {message && <div className="message">{message}</div>}
     </div>
   )

--- a/src/HeaderMenu.css
+++ b/src/HeaderMenu.css
@@ -26,6 +26,24 @@
   gap: 1rem;
 }
 
+.menu-items a {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #1a1a1a;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  transition: border-color 0.25s;
+}
+
+.menu-items a:hover {
+  border-color: #646cff;
+}
+
 @media (max-width: 600px) {
   .menu-toggle {
     display: block;
@@ -40,6 +58,10 @@
     flex-direction: column;
     background-color: rgba(0, 0, 0, 0.3);
     padding: 0.5rem 0;
+  }
+
+  .menu-items a {
+    text-align: center;
   }
 
   .menu-items.open {

--- a/src/HeaderMenu.tsx
+++ b/src/HeaderMenu.tsx
@@ -11,11 +11,11 @@ export default function HeaderMenu() {
         ☰
       </button>
       <nav className={`menu-items${open ? ' open' : ''}`} onClick={() => setOpen(false)}>
-        <button>Home</button>
-        <button>Services</button>
-        <button>Prices</button>
-        <button>Contacts</button>
-        <button>About</button>
+        <a href="#home">Home</a>
+        <a href="#services">Services</a>
+        <a href="#prices">Prices</a>
+        <a href="#contacts">Contacts</a>
+        <a href="#about">About</a>
       </nav>
     </header>
   )

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -220,7 +220,7 @@ export default function ThreeScene({
 
   return (
     <Canvas
-      style={{ height: '100vh', width: '100vw' }}
+      style={{ position: 'fixed', top: 0, left: 0, height: '100vh', width: '100vw', zIndex: 0 }}
       onContextMenu={(e) => {
         e.preventDefault()
         setSelected(null)

--- a/src/index.css
+++ b/src/index.css
@@ -24,10 +24,7 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
-  min-height: 100vh;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- create menu-section blocks for `Home`, `Services`, `Prices`, `Contacts`, and `About`
- link header buttons to these sections
- style menu items as links and set mobile styles
- make Canvas a fixed background
- allow page scrolling and keep sections above 3D scene

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848b437c460832f9dd9fe2c714d9e0f