### PR TITLE
Center burger menu and tweak tool panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,21 @@
 .app {
-  height: 100vh;
-  width: 100vw;
+  width: 100%;
+  min-height: 100vh;
   margin: 0;
   position: relative;
+}
+
+.menu-section {
+  position: relative;
+  z-index: 1;
+  width: 80vw;
+  height: 80vh;
+  margin: 10vh auto;
+  background-color: rgba(255, 255, 255, 0.5);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .message {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,16 +98,6 @@ export default function App() {
 
   return (
     <div className="app">
-      <HeaderMenu />
-      <ToolPanel
-        onAddPlane={addPlane}
-        pointEnabled={mode === 'placePoint'}
-        onTogglePoint={togglePointPlacement}
-        lineEnabled={mode === 'placeLine'}
-        onToggleLine={toggleLineDrawing}
-        moveEnabled={mode === 'move'}
-        onToggleMove={toggleMove}
-      />
       <ThreeScene
         planes={planes}
         points={points}
@@ -121,6 +111,31 @@ export default function App() {
         onCancelLineChain={cancelLineChain}
         onCancelMove={cancelMove}
       />
+      <HeaderMenu />
+      <ToolPanel
+        onAddPlane={addPlane}
+        pointEnabled={mode === 'placePoint'}
+        onTogglePoint={togglePointPlacement}
+        lineEnabled={mode === 'placeLine'}
+        onToggleLine={toggleLineDrawing}
+        moveEnabled={mode === 'move'}
+        onToggleMove={toggleMove}
+      />
+      <section id="home" className="menu-section">
+        <h2>Home</h2>
+      </section>
+      <section id="services" className="menu-section">
+        <h2>Services</h2>
+      </section>
+      <section id="prices" className="menu-section">
+        <h2>Prices</h2>
+      </section>
+      <section id="contacts" className="menu-section">
+        <h2>Contacts</h2>
+      </section>
+      <section id="about" className="menu-section">
+        <h2>About</h2>
+      </section>
       {message && <div className="message">{message}</div>}
     </div>
   )

--- a/src/HeaderMenu.css
+++ b/src/HeaderMenu.css
@@ -1,5 +1,5 @@
 .header-menu {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;
@@ -7,7 +7,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.5rem 0;
+  height: var(--header-base-height);
+  padding: 2em 1rem;
   z-index: 20;
 }
 
@@ -26,9 +27,28 @@
   gap: 1rem;
 }
 
+.menu-items a {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #1a1a1a;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  transition: border-color 0.25s;
+}
+
+.menu-items a:hover {
+  border-color: #646cff;
+}
+
 @media (max-width: 600px) {
   .menu-toggle {
     display: block;
+    margin: 0 auto;
   }
 
   .menu-items {
@@ -40,6 +60,11 @@
     flex-direction: column;
     background-color: rgba(0, 0, 0, 0.3);
     padding: 0.5rem 0;
+    gap: 0;
+  }
+
+  .menu-items a {
+    text-align: center;
   }
 
   .menu-items.open {

--- a/src/HeaderMenu.css
+++ b/src/HeaderMenu.css
@@ -51,6 +51,10 @@
     margin: 0 auto;
   }
 
+  .header-menu {
+    padding: 0;
+  }
+
   .menu-items {
     display: none;
     position: absolute;

--- a/src/HeaderMenu.tsx
+++ b/src/HeaderMenu.tsx
@@ -11,11 +11,11 @@ export default function HeaderMenu() {
         ☰
       </button>
       <nav className={`menu-items${open ? ' open' : ''}`} onClick={() => setOpen(false)}>
-        <button>Home</button>
-        <button>Services</button>
-        <button>Prices</button>
-        <button>Contacts</button>
-        <button>About</button>
+        <a href="#home">Home</a>
+        <a href="#services">Services</a>
+        <a href="#prices">Prices</a>
+        <a href="#contacts">Contacts</a>
+        <a href="#about">About</a>
       </nav>
     </header>
   )

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -220,7 +220,7 @@ export default function ThreeScene({
 
   return (
     <Canvas
-      style={{ height: '100vh', width: '100vw' }}
+      style={{ position: 'fixed', top: 0, left: 0, height: '100vh', width: '100vw', zIndex: 0 }}
       onContextMenu={(e) => {
         e.preventDefault()
         setSelected(null)

--- a/src/ToolPanel.css
+++ b/src/ToolPanel.css
@@ -1,8 +1,8 @@
 .tool-panel-container {
-  position: absolute;
+  position: fixed;
   left: -80px;
-  top: 0;
-  height: 100vh;
+  top: var(--header-height);
+  height: calc(100vh - var(--header-height));
   width: 80px;
   z-index: 10;
   transition: left 0.3s ease;
@@ -16,13 +16,17 @@
   position: absolute;
   left: 0;
   top: 0;
-  height: 100vh;
+  height: 100%;
   width: 80px;
   background-color: rgba(0, 0, 0, 0.3);
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 1rem;
+  padding: 1rem 1em 0 1em;
+}
+
+.tool-panel button {
+  background-color: transparent;
 }
 
 .panel-toggle {

--- a/src/ToolPanel.css
+++ b/src/ToolPanel.css
@@ -22,11 +22,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1rem 1em 0 1em;
+  padding: 0;
 }
 
 .tool-panel button {
   background-color: transparent;
+  padding: 0.6em 0.5em;
 }
 
 .panel-toggle {

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,6 @@
 :root {
+  --header-base-height: 48px;
+  --header-height: calc(var(--header-base-height) + 4em);
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
@@ -24,10 +26,7 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
-  min-height: 100vh;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- center burger menu button and remove gaps in its mobile dropdown
- make tool panel buttons transparent and give the panel horizontal padding

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848b437c460832f9dd9fe2c714d9e0f