### PR TITLE
Add model upload tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@types/three": "^0.177.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "three": "^0.177.0"
+        "three": "^0.177.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -3465,6 +3466,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@types/three": "^0.177.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "three": "^0.177.0"
+    "three": "^0.177.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import ToolPanel from './ToolPanel'
 import HeaderMenu from './HeaderMenu'
 import type { LineData, LineEnd, PointData, ModelData } from './types'
 import { loadModel } from './loadModel'
+import { v4 as uuidv4 } from 'uuid'
 import './App.css'
 
 export default function App() {
@@ -39,7 +40,7 @@ export default function App() {
         const object = await loadModel(file)
         setModels((prev) => [
           ...prev,
-          { id: `model-${prev.length}`, object },
+          { id: uuidv4(), object },
         ])
         setMessage('Model uploaded')
       } catch (e) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,14 @@ import { useEffect, useState } from 'react'
 import ThreeScene from './ThreeScene'
 import ToolPanel from './ToolPanel'
 import HeaderMenu from './HeaderMenu'
-import type { LineData, LineEnd, PointData } from './types'
+import type { LineData, LineEnd, PointData, ModelData } from './types'
+import { loadModel } from './loadModel'
 import './App.css'
 
 export default function App() {
   const [planes, setPlanes] = useState<number[]>([])
+
+  const [models, setModels] = useState<ModelData[]>([])
 
   const [points, setPoints] = useState<PointData[]>([])
   const [lines, setLines] = useState<LineData[]>([])
@@ -28,6 +31,22 @@ export default function App() {
 
   const cancelMove = () => {
     setMode('idle')
+  }
+
+  const handleUploadModels = async (files: FileList) => {
+    for (const file of Array.from(files)) {
+      try {
+        const object = await loadModel(file)
+        setModels((prev) => [
+          ...prev,
+          { id: `model-${prev.length}`, object },
+        ])
+        setMessage('Model uploaded')
+      } catch (e) {
+        console.error(e)
+        setMessage('Failed to load model')
+      }
+    }
   }
 
   const togglePointPlacement = () => {
@@ -102,6 +121,7 @@ export default function App() {
         planes={planes}
         points={points}
         lines={lines}
+        models={models}
         tempLine={{ start: lineStart, end: tempLineEnd }}
         mode={mode}
         onAddPoint={handlePointAdd}
@@ -120,6 +140,9 @@ export default function App() {
         onToggleLine={toggleLineDrawing}
         moveEnabled={mode === 'move'}
         onToggleMove={toggleMove}
+        onUpload={(files) => {
+          void handleUploadModels(files)
+        }}
       />
       <section id="home" className="menu-section">
         <h2>Home</h2>

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -5,7 +5,7 @@ import type { JSX } from 'react'
 import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
 import { DoubleSide, Object3D, Vector3, Quaternion } from 'three'
 import type { BufferGeometry, BufferAttribute } from 'three'
-import type { LineData, LineEnd, PointData } from './types'
+import type { LineData, LineEnd, PointData, ModelData } from './types'
 import { useObjectInteractions } from './useObjectInteractions'
 
 
@@ -164,10 +164,50 @@ function LineObject({ line, objectMap }: { line: LineData; objectMap: React.Muta
   )
 }
 
+function ImportedModel({
+  model,
+  objectId,
+  onSelect,
+  selectedObject,
+  mode,
+  onAddPoint,
+  onAddLinePoint,
+  onUpdateTempLineEnd,
+  registerObject,
+}: {
+  model: Object3D
+  objectId: string
+  onSelect: (obj: Object3D) => void
+  selectedObject: Object3D | null
+  mode: 'idle' | 'move' | 'placePoint' | 'placeLine'
+  onAddPoint: (point: PointData) => void
+  onAddLinePoint: (point: LineEnd) => void
+  onUpdateTempLineEnd: (point: LineEnd) => void
+  registerObject: (id: string, obj: Object3D | null) => void
+}) {
+  const { ref, handlePointerDown, handlePointerMove } = useObjectInteractions({
+    objectId,
+    onSelect,
+    selectedObject,
+    mode,
+    onAddPoint,
+    onAddLinePoint,
+    onUpdateTempLineEnd,
+    registerObject,
+  })
+
+  return (
+    <group ref={ref} onPointerDown={handlePointerDown} onPointerMove={handlePointerMove}>
+      <primitive object={model} />
+    </group>
+  )
+}
+
 interface ThreeSceneProps {
   planes: number[]
   points: PointData[]
   lines: LineData[]
+  models: ModelData[]
   tempLine: { start: LineEnd | null; end: LineEnd | null }
   mode: 'idle' | 'move' | 'placePoint' | 'placeLine'
   onAddPoint: (point: PointData) => void
@@ -182,6 +222,7 @@ export default function ThreeScene({
   planes,
   points,
   lines,
+  models,
   tempLine,
   mode,
   onAddPoint,
@@ -248,6 +289,20 @@ export default function ThreeScene({
           key={id}
           objectId={`plane-${id}`}
           position={[0, 0, 0]}
+          onSelect={setSelected}
+          selectedObject={selected}
+          mode={mode}
+          onAddPoint={onAddPoint}
+          onAddLinePoint={onAddLinePoint}
+          onUpdateTempLineEnd={onUpdateTempLineEnd}
+          registerObject={registerObject}
+        />
+      ))}
+      {models.map((m) => (
+        <ImportedModel
+          key={m.id}
+          objectId={m.id}
+          model={m.object}
           onSelect={setSelected}
           selectedObject={selected}
           mode={mode}

--- a/src/ToolPanel.tsx
+++ b/src/ToolPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import './ToolPanel.css'
 
 interface ToolPanelProps {
@@ -9,6 +9,7 @@ interface ToolPanelProps {
   onToggleLine: () => void
   moveEnabled: boolean
   onToggleMove: () => void
+  onUpload: (files: FileList) => void
 }
 
 export default function ToolPanel({
@@ -19,8 +20,10 @@ export default function ToolPanel({
   onToggleLine,
   moveEnabled,
   onToggleMove,
+  onUpload,
 }: ToolPanelProps) {
   const [open, setOpen] = useState(false)
+  const fileRef = useRef<HTMLInputElement>(null)
 
   return (
     <div className={`tool-panel-container${open ? ' open' : ''}`}> 
@@ -44,6 +47,25 @@ export default function ToolPanel({
         >
           Line
         </button>
+        <button
+          style={{ marginTop: 'auto', marginBottom: '1rem' }}
+          onClick={() => fileRef.current?.click()}
+        >
+          Upload
+        </button>
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".fbx,.gltf,.glb"
+          multiple
+          style={{ display: 'none' }}
+          onChange={(e) => {
+            if (e.target.files) {
+              onUpload(e.target.files)
+              e.target.value = ''
+            }
+          }}
+        />
       </div>
       <div
         className="panel-toggle"

--- a/src/loadModel.ts
+++ b/src/loadModel.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
+import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader'
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
+import type { Object3D } from 'three'
+
+export async function loadModel(file: File): Promise<Object3D> {
+  const url = URL.createObjectURL(file)
+  const ext = file.name.split('.').pop()?.toLowerCase()
+  return new Promise((resolve, reject) => {
+    const cleanup = () => URL.revokeObjectURL(url)
+    if (ext === 'fbx') {
+      new FBXLoader().load(
+        url,
+        (obj) => {
+          cleanup()
+          resolve(obj)
+        },
+        undefined,
+        (err) => {
+          cleanup()
+          reject(err instanceof Error ? err : new Error(String(err)))
+        },
+      )
+    } else if (ext === 'gltf' || ext === 'glb') {
+      new GLTFLoader().load(
+        url,
+        (gltf) => {
+          cleanup()
+          resolve(gltf.scene)
+        },
+        undefined,
+        (err) => {
+          cleanup()
+          reject(err instanceof Error ? err : new Error(String(err)))
+        },
+      )
+    } else {
+      cleanup()
+      reject(new Error('Unsupported file type'))
+    }
+  })
+}

--- a/src/loadModel.ts
+++ b/src/loadModel.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
-import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
+import { FBXLoader, GLTFLoader } from 'three-stdlib'
 import type { Object3D } from 'three'
+import type { GLTF } from 'three-stdlib'
 
 export async function loadModel(file: File): Promise<Object3D> {
   const url = URL.createObjectURL(file)
@@ -11,12 +10,12 @@ export async function loadModel(file: File): Promise<Object3D> {
     if (ext === 'fbx') {
       new FBXLoader().load(
         url,
-        (obj) => {
+        (obj: Object3D) => {
           cleanup()
           resolve(obj)
         },
         undefined,
-        (err) => {
+        (err: unknown) => {
           cleanup()
           reject(err instanceof Error ? err : new Error(String(err)))
         },
@@ -24,12 +23,12 @@ export async function loadModel(file: File): Promise<Object3D> {
     } else if (ext === 'gltf' || ext === 'glb') {
       new GLTFLoader().load(
         url,
-        (gltf) => {
+        (gltf: GLTF) => {
           cleanup()
           resolve(gltf.scene)
         },
         undefined,
-        (err) => {
+        (err: unknown) => {
           cleanup()
           reject(err instanceof Error ? err : new Error(String(err)))
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,3 +13,8 @@ export interface LineData {
   start: LineEnd
   end: LineEnd
 }
+
+export interface ModelData {
+  id: string
+  object: import('three').Object3D
+}


### PR DESCRIPTION
## Summary
- allow uploading FBX and GLTF/GLB models
- render uploaded models in the Three.js scene
- add `ModelData` type and model loader utility

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68530e0a5a00832fb1351c2263154c66