### PR TITLE
Add upload tool for FBX, GLTF and STL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import ThreeScene from './ThreeScene'
 import ToolPanel from './ToolPanel'
 import HeaderMenu from './HeaderMenu'
 import type { LineData, LineEnd, PointData } from './types'
+import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader.js'
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js'
+import { MeshStandardMaterial, Mesh, Object3D } from 'three'
+import type { UploadData } from './types'
 import './App.css'
 
 export default function App() {
@@ -10,6 +15,8 @@ export default function App() {
 
   const [points, setPoints] = useState<PointData[]>([])
   const [lines, setLines] = useState<LineData[]>([])
+  const [uploads, setUploads] = useState<UploadData[]>([])
+  const uploadCounter = useRef(0)
   const [lineStart, setLineStart] = useState<LineEnd | null>(null)
   const [tempLineEnd, setTempLineEnd] = useState<LineEnd | null>(null)
   const [mode, setMode] =
@@ -28,6 +35,82 @@ export default function App() {
 
   const cancelMove = () => {
     setMode('idle')
+  }
+
+  const loadModel = (file: File): Promise<Object3D> => {
+    const ext = file.name.split('.').pop()?.toLowerCase()
+    const url = URL.createObjectURL(file)
+    return new Promise((resolve, reject) => {
+      const revoke = () => URL.revokeObjectURL(url)
+      if (ext === 'fbx') {
+        new FBXLoader().load(
+          url,
+          (obj) => {
+            revoke()
+            resolve(obj)
+          },
+          undefined,
+          (err) => {
+            revoke()
+            reject(
+              err instanceof Error ? err : new Error('Failed to load model'),
+            )
+          },
+        )
+      } else if (ext === 'gltf' || ext === 'glb') {
+        new GLTFLoader().load(
+          url,
+          (gltf) => {
+            revoke()
+            resolve(gltf.scene)
+          },
+          undefined,
+          (err) => {
+            revoke()
+            reject(
+              err instanceof Error ? err : new Error('Failed to load model'),
+            )
+          },
+        )
+      } else if (ext === 'stl') {
+        new STLLoader().load(
+          url,
+          (geom) => {
+            revoke()
+            resolve(
+              new Mesh(geom, new MeshStandardMaterial({ color: 'white' })),
+            )
+          },
+          undefined,
+          (err) => {
+            revoke()
+            reject(
+              err instanceof Error ? err : new Error('Failed to load model'),
+            )
+          },
+        )
+      } else {
+        revoke()
+        reject(new Error('Unsupported file type'))
+      }
+    })
+  }
+
+  const handleUpload = (files: FileList | null): void => {
+    if (!files) return
+    void (async () => {
+      for (const file of Array.from(files)) {
+        try {
+          const object = await loadModel(file)
+          const id = uploadCounter.current++
+          setUploads((prev) => [...prev, { id, object }])
+          setMessage(`${file.name} loaded`)
+        } catch (e) {
+          console.error(e)
+          setMessage(`Failed to load ${file.name}`)
+        }
+      }
+    })()
   }
 
   const togglePointPlacement = () => {
@@ -102,6 +185,7 @@ export default function App() {
         planes={planes}
         points={points}
         lines={lines}
+        uploads={uploads}
         tempLine={{ start: lineStart, end: tempLineEnd }}
         mode={mode}
         onAddPoint={handlePointAdd}
@@ -120,6 +204,7 @@ export default function App() {
         onToggleLine={toggleLineDrawing}
         moveEnabled={mode === 'move'}
         onToggleMove={toggleMove}
+        onUpload={handleUpload}
       />
       <section id="home" className="menu-section">
         <h2>Home</h2>

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -5,7 +5,7 @@ import type { JSX } from 'react'
 import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
 import { DoubleSide, Object3D, Vector3, Quaternion } from 'three'
 import type { BufferGeometry, BufferAttribute } from 'three'
-import type { LineData, LineEnd, PointData } from './types'
+import type { LineData, LineEnd, PointData, UploadData } from './types'
 import { useObjectInteractions } from './useObjectInteractions'
 
 
@@ -164,10 +164,52 @@ function LineObject({ line, objectMap }: { line: LineData; objectMap: React.Muta
   )
 }
 
+function UploadedObject({
+  objectId,
+  object,
+  onSelect,
+  selectedObject,
+  mode,
+  onAddPoint,
+  onAddLinePoint,
+  onUpdateTempLineEnd,
+  registerObject,
+}: {
+  objectId: string
+  object: Object3D
+  onSelect: (obj: Object3D) => void
+  selectedObject: Object3D | null
+  mode: 'idle' | 'move' | 'placePoint' | 'placeLine'
+  onAddPoint: (point: PointData) => void
+  onAddLinePoint: (point: LineEnd) => void
+  onUpdateTempLineEnd: (point: LineEnd) => void
+  registerObject: (id: string, obj: Object3D | null) => void
+}) {
+  const { ref, handlePointerDown, handlePointerMove } = useObjectInteractions({
+    objectId,
+    onSelect,
+    selectedObject,
+    mode,
+    onAddPoint,
+    onAddLinePoint,
+    onUpdateTempLineEnd,
+    registerObject,
+  })
+  return (
+    <primitive
+      ref={ref}
+      object={object}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+    />
+  )
+}
+
 interface ThreeSceneProps {
   planes: number[]
   points: PointData[]
   lines: LineData[]
+  uploads: UploadData[]
   tempLine: { start: LineEnd | null; end: LineEnd | null }
   mode: 'idle' | 'move' | 'placePoint' | 'placeLine'
   onAddPoint: (point: PointData) => void
@@ -182,6 +224,7 @@ export default function ThreeScene({
   planes,
   points,
   lines,
+  uploads,
   tempLine,
   mode,
   onAddPoint,
@@ -243,6 +286,20 @@ export default function ThreeScene({
         onUpdateTempLineEnd={onUpdateTempLineEnd}
         registerObject={registerObject}
       />
+      {uploads.map((u) => (
+        <UploadedObject
+          key={u.id}
+          objectId={`upload-${u.id}`}
+          object={u.object}
+          onSelect={setSelected}
+          selectedObject={selected}
+          mode={mode}
+          onAddPoint={onAddPoint}
+          onAddLinePoint={onAddLinePoint}
+          onUpdateTempLineEnd={onUpdateTempLineEnd}
+          registerObject={registerObject}
+        />
+      ))}
       {planes.map((id) => (
         <Plane
           key={id}

--- a/src/ToolPanel.css
+++ b/src/ToolPanel.css
@@ -42,3 +42,8 @@
 .tool-panel button.active {
   border-color: #646cff;
 }
+
+.tool-panel .upload-button {
+  margin-top: auto;
+  margin-bottom: 1rem;
+}

--- a/src/ToolPanel.tsx
+++ b/src/ToolPanel.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
+import type React from 'react'
 import './ToolPanel.css'
 
 interface ToolPanelProps {
@@ -9,6 +10,7 @@ interface ToolPanelProps {
   onToggleLine: () => void
   moveEnabled: boolean
   onToggleMove: () => void
+  onUpload: (files: FileList | null) => void
 }
 
 export default function ToolPanel({
@@ -19,8 +21,10 @@ export default function ToolPanel({
   onToggleLine,
   moveEnabled,
   onToggleMove,
+  onUpload,
 }: ToolPanelProps) {
   const [open, setOpen] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   return (
     <div className={`tool-panel-container${open ? ' open' : ''}`}> 
@@ -43,6 +47,23 @@ export default function ToolPanel({
           onClick={onToggleLine}
         >
           Line
+        </button>
+        <input
+          type="file"
+          ref={fileInputRef}
+          accept=".fbx,.gltf,.glb,.stl"
+          multiple
+          style={{ display: 'none' }}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            onUpload(e.target.files)
+            e.target.value = ''
+          }}
+        />
+        <button
+          className="upload-button"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          Upload
         </button>
       </div>
       <div

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Object3D } from 'three'
+
 export interface PointData {
   objectId: string
   position: [number, number, number]
@@ -12,4 +14,9 @@ export interface LineEnd {
 export interface LineData {
   start: LineEnd
   end: LineEnd
+}
+
+export interface UploadData {
+  id: number
+  object: Object3D
 }


### PR DESCRIPTION
## Summary
- add file upload control inside tools panel
- style upload button at bottom of panel
- support loading FBX, GLTF/GLB and STL models
- render uploaded models in ThreeScene
- define `UploadData` type and use it throughout the app
- improve TypeScript annotations on file upload

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.app.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68531c61d5c8832f9cc02f76e383b216