### PR TITLE
Add edit mode for per-mesh transforms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ export default function App() {
   const [lineStart, setLineStart] = useState<LineEnd | null>(null)
   const [tempLineEnd, setTempLineEnd] = useState<LineEnd | null>(null)
   const [mode, setMode] =
-    useState<'idle' | 'move' | 'placePoint' | 'placeLine'>('idle')
+    useState<'idle' | 'move' | 'placePoint' | 'placeLine' | 'edit'>('idle')
   const [message, setMessage] = useState<string | null>(null)
   const [uiVisible, setUiVisible] = useState(true)
 
@@ -38,6 +38,11 @@ export default function App() {
 
   const toggleMove = () => {
     setMode((prev) => (prev === 'move' ? 'idle' : 'move'))
+    setMessage(null)
+  }
+
+  const toggleEdit = () => {
+    setMode((prev) => (prev === 'edit' ? 'idle' : 'edit'))
     setMessage(null)
   }
 
@@ -224,6 +229,8 @@ export default function App() {
         onToggleLine={toggleLineDrawing}
         moveEnabled={mode === 'move'}
         onToggleMove={toggleMove}
+        editEnabled={mode === 'edit'}
+        onToggleEdit={toggleEdit}
         onToggleUI={toggleUI}
         onUpload={handleUpload}
       />

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -34,6 +34,8 @@ function Box({
     isSelected,
     handlePointerDown,
     handlePointerMove,
+    handlePointerOver,
+    handlePointerOut,
   } = useObjectInteractions({
     objectId,
     onSelect,
@@ -50,6 +52,8 @@ function Box({
       {...props}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
+      onPointerOver={handlePointerOver}
+      onPointerOut={handlePointerOut}
     >
       <boxGeometry args={[1, 1, 1]} />
       <meshStandardMaterial
@@ -86,6 +90,8 @@ function Plane({
     isSelected,
     handlePointerDown,
     handlePointerMove,
+    handlePointerOver,
+    handlePointerOut,
   } = useObjectInteractions({
     objectId,
     onSelect,
@@ -103,6 +109,8 @@ function Plane({
       {...props}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
+      onPointerOver={handlePointerOver}
+      onPointerOut={handlePointerOut}
     >
       <planeGeometry args={[10, 10]} />
       <meshStandardMaterial
@@ -187,7 +195,13 @@ function UploadedObject({
   registerObject: (id: string, obj: Object3D | null) => void
   highlight: boolean
 }) {
-  const { ref, handlePointerDown, handlePointerMove } = useObjectInteractions({
+  const {
+    ref,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerOver,
+    handlePointerOut,
+  } = useObjectInteractions({
     objectId,
     onSelect,
     selectedObject,
@@ -224,6 +238,8 @@ function UploadedObject({
         object={object}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
+        onPointerOver={handlePointerOver}
+        onPointerOut={handlePointerOut}
       />
     </group>
   )

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -23,7 +23,7 @@ function Box({
   objectId: string
   onSelect: (obj: Object3D) => void
   selectedObject: Object3D | null
-  mode: 'idle' | 'move' | 'placePoint' | 'placeLine'
+  mode: 'idle' | 'move' | 'placePoint' | 'placeLine' | 'edit'
   onAddPoint: (point: PointData) => void
   onAddLinePoint: (point: LineEnd) => void
   onUpdateTempLineEnd: (point: LineEnd) => void
@@ -75,7 +75,7 @@ function Plane({
   objectId: string
   onSelect: (obj: Object3D) => void
   selectedObject: Object3D | null
-  mode: 'idle' | 'move' | 'placePoint' | 'placeLine'
+  mode: 'idle' | 'move' | 'placePoint' | 'placeLine' | 'edit'
   onAddPoint: (point: PointData) => void
   onAddLinePoint: (point: LineEnd) => void
   onUpdateTempLineEnd: (point: LineEnd) => void
@@ -180,7 +180,7 @@ function UploadedObject({
   object: Object3D
   onSelect: (obj: Object3D) => void
   selectedObject: Object3D | null
-  mode: 'idle' | 'move' | 'placePoint' | 'placeLine'
+  mode: 'idle' | 'move' | 'placePoint' | 'placeLine' | 'edit'
   onAddPoint: (point: PointData) => void
   onAddLinePoint: (point: LineEnd) => void
   onUpdateTempLineEnd: (point: LineEnd) => void
@@ -236,7 +236,7 @@ interface ThreeSceneProps {
   uploads: UploadData[]
   focusUploadId: number | null
   tempLine: { start: LineEnd | null; end: LineEnd | null }
-  mode: 'idle' | 'move' | 'placePoint' | 'placeLine'
+  mode: 'idle' | 'move' | 'placePoint' | 'placeLine' | 'edit'
   onAddPoint: (point: PointData) => void
   onAddLinePoint: (point: LineEnd) => void
   onUpdateTempLineEnd: (point: LineEnd) => void
@@ -278,7 +278,7 @@ export default function ThreeScene({
         setSelected(null)
         if (mode === 'placePoint' || mode === 'placeLine') {
           onCancelPointPlacement()
-        } else if (mode === 'move') {
+        } else if (mode === 'move' || mode === 'edit') {
           onCancelMove()
         }
       }
@@ -366,7 +366,7 @@ export default function ThreeScene({
         if (!objectMap.current[tempLine.start.objectId] || !objectMap.current[tempLine.end.objectId]) return null
         return <LineObject line={{ start: tempLine.start, end: tempLine.end }} objectMap={objectMap} />
       })()}
-      {selected && mode === 'move' && (
+      {selected && (mode === 'move' || mode === 'edit') && (
         <TransformControls
           object={selected}
           mode="translate"

--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -34,7 +34,6 @@ function Box({
     isSelected,
     handlePointerDown,
     handlePointerMove,
-    handlePointerOver,
     handlePointerOut,
   } = useObjectInteractions({
     objectId,
@@ -52,7 +51,6 @@ function Box({
       {...props}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
-      onPointerOver={handlePointerOver}
       onPointerOut={handlePointerOut}
     >
       <boxGeometry args={[1, 1, 1]} />
@@ -90,7 +88,6 @@ function Plane({
     isSelected,
     handlePointerDown,
     handlePointerMove,
-    handlePointerOver,
     handlePointerOut,
   } = useObjectInteractions({
     objectId,
@@ -109,7 +106,6 @@ function Plane({
       {...props}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
-      onPointerOver={handlePointerOver}
       onPointerOut={handlePointerOut}
     >
       <planeGeometry args={[10, 10]} />
@@ -199,7 +195,6 @@ function UploadedObject({
     ref,
     handlePointerDown,
     handlePointerMove,
-    handlePointerOver,
     handlePointerOut,
   } = useObjectInteractions({
     objectId,
@@ -238,7 +233,6 @@ function UploadedObject({
         object={object}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
-        onPointerOver={handlePointerOver}
         onPointerOut={handlePointerOut}
       />
     </group>

--- a/src/ToolPanel.tsx
+++ b/src/ToolPanel.tsx
@@ -10,6 +10,8 @@ interface ToolPanelProps {
   onToggleLine: () => void
   moveEnabled: boolean
   onToggleMove: () => void
+  editEnabled: boolean
+  onToggleEdit: () => void
   onToggleUI: () => void
   onUpload: (files: FileList | null) => void
 }
@@ -22,6 +24,8 @@ export default function ToolPanel({
   onToggleLine,
   moveEnabled,
   onToggleMove,
+  editEnabled,
+  onToggleEdit,
   onToggleUI,
   onUpload,
 }: ToolPanelProps) {
@@ -36,6 +40,12 @@ export default function ToolPanel({
           onClick={onToggleMove}
         >
           Move
+        </button>
+        <button
+          className={editEnabled ? 'active' : ''}
+          onClick={onToggleEdit}
+        >
+          Edit
         </button>
         <button onClick={onAddPlane}>Plane</button>
         <button

--- a/src/useObjectInteractions.ts
+++ b/src/useObjectInteractions.ts
@@ -59,6 +59,9 @@ export function useObjectInteractions({
     const local = ref.current
       .worldToLocal(e.point.clone())
       .toArray() as [number, number, number]
+    if ((e.eventObject as Mesh).isMesh) {
+      console.log((e.eventObject as Mesh).name)
+    }
     if (mode === 'placePoint') {
       if (e.button !== 0) return
       const normal = e.face?.normal?.clone()
@@ -90,12 +93,16 @@ export function useObjectInteractions({
 
   const handlePointerOver = (e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation()
-    applyHighlight(e.eventObject, true)
+    if (mode === 'move' || mode === 'edit') {
+      applyHighlight(e.eventObject, true)
+    }
   }
 
   const handlePointerOut = (e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation()
-    applyHighlight(e.eventObject, false)
+    if (mode === 'move' || mode === 'edit') {
+      applyHighlight(e.eventObject, false)
+    }
   }
 
   return {

--- a/src/useObjectInteractions.ts
+++ b/src/useObjectInteractions.ts
@@ -59,9 +59,7 @@ export function useObjectInteractions({
     const local = ref.current
       .worldToLocal(e.point.clone())
       .toArray() as [number, number, number]
-    if ((e.eventObject as Mesh).isMesh) {
-      console.log((e.eventObject as Mesh).name)
-    }
+    console.log(e)
     if (mode === 'placePoint') {
       if (e.button !== 0) return
       const normal = e.face?.normal?.clone()

--- a/src/useObjectInteractions.ts
+++ b/src/useObjectInteractions.ts
@@ -16,7 +16,7 @@ export function useObjectInteractions({
   objectId: string
   onSelect: (obj: Object3D) => void
   selectedObject: Object3D | null
-  mode: 'idle' | 'move' | 'placePoint' | 'placeLine'
+  mode: 'idle' | 'move' | 'placePoint' | 'placeLine' | 'edit'
   onAddPoint: (point: PointData) => void
   onAddLinePoint: (point: LineEnd) => void
   onUpdateTempLineEnd: (point: LineEnd) => void
@@ -51,6 +51,8 @@ export function useObjectInteractions({
       onAddLinePoint({ objectId, position: local })
     } else if (mode === 'move') {
       onSelect(ref.current)
+    } else if (mode === 'edit') {
+      onSelect(e.eventObject)
     }
   }
 


### PR DESCRIPTION
## Summary
- support `edit` mode in scene interactions
- enable mesh-level selection in `useObjectInteractions`
- add Edit button to tool panel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685482e16cd8832f88da1d1ce3717ea5