### PR TITLE
Improve part selection handling

### DIFF
--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -308,7 +308,7 @@ export default function ThreeScene({
 }: ThreeSceneProps) {
   const [selected, setSelected] = useState<Object3D | null>(null)
   const centerRef = useRef<Object3D>(new Object3D())
-  const lastCenter = useRef<Vector3>(new Vector3())
+  const centerOffset = useRef<Vector3>(new Vector3())
   const orbitRef = useRef<OrbitControlsImpl | null>(null)
   const objectMap = useRef<Record<string, Object3D | null>>({})
   const registerObject = (id: string, obj: Object3D | null) => {
@@ -320,7 +320,8 @@ export default function ThreeScene({
     const box = new Box3().setFromObject(selected)
     const center = box.getCenter(new Vector3())
     centerRef.current.position.copy(center)
-    lastCenter.current.copy(center)
+    const origin = selected.getWorldPosition(new Vector3())
+    centerOffset.current.copy(origin.sub(center))
   }, [selected])
 
   useEffect(() => {
@@ -436,10 +437,8 @@ export default function ThreeScene({
           mode="translate"
           onObjectChange={() => {
             if (!selected) return
-            const newPos = centerRef.current.position.clone()
-            const delta = newPos.clone().sub(lastCenter.current)
-            lastCenter.current.copy(newPos)
-            const worldPos = selected.getWorldPosition(new Vector3()).add(delta)
+            const newCenter = centerRef.current.position.clone()
+            const worldPos = newCenter.clone().add(centerOffset.current)
             if (selected.parent) {
               selected.position.copy(selected.parent.worldToLocal(worldPos))
             } else {


### PR DESCRIPTION
## Summary
- persist highlight on selected object
- move transform controls to the center of the selected part

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855a619a1f0832f90f0e074f1e3b803