### PR TITLE
Implement outline selection highlight

### DIFF
--- a/src/ThreeScene.tsx
+++ b/src/ThreeScene.tsx
@@ -29,22 +29,17 @@ function Box({
   onUpdateTempLineEnd: (point: LineEnd) => void
   registerObject: (id: string, obj: Object3D | null) => void
 }) {
-  const {
-    ref,
-    isSelected,
-    handlePointerDown,
-    handlePointerMove,
-    handlePointerOut,
-  } = useObjectInteractions({
-    objectId,
-    onSelect,
-    selectedObject,
-    mode,
-    onAddPoint,
-    onAddLinePoint,
-    onUpdateTempLineEnd,
-    registerObject,
-  })
+  const { ref, handlePointerDown, handlePointerMove, handlePointerOut } =
+    useObjectInteractions({
+      objectId,
+      onSelect,
+      selectedObject,
+      mode,
+      onAddPoint,
+      onAddLinePoint,
+      onUpdateTempLineEnd,
+      registerObject,
+    })
   return (
     <mesh
       ref={ref}
@@ -54,11 +49,7 @@ function Box({
       onPointerOut={handlePointerOut}
     >
       <boxGeometry args={[1, 1, 1]} />
-      <meshStandardMaterial
-        color={isSelected ? '#00008B' : 'orange'}
-        transparent
-        opacity={isSelected ? 0.8 : 1}
-      />
+      <meshStandardMaterial color="orange" />
     </mesh>
   )
 }
@@ -83,22 +74,17 @@ function Plane({
   onUpdateTempLineEnd: (point: LineEnd) => void
   registerObject: (id: string, obj: Object3D | null) => void
 }) {
-  const {
-    ref,
-    isSelected,
-    handlePointerDown,
-    handlePointerMove,
-    handlePointerOut,
-  } = useObjectInteractions({
-    objectId,
-    onSelect,
-    selectedObject,
-    mode,
-    onAddPoint,
-    onAddLinePoint,
-    onUpdateTempLineEnd,
-    registerObject,
-  })
+  const { ref, handlePointerDown, handlePointerMove, handlePointerOut } =
+    useObjectInteractions({
+      objectId,
+      onSelect,
+      selectedObject,
+      mode,
+      onAddPoint,
+      onAddLinePoint,
+      onUpdateTempLineEnd,
+      registerObject,
+    })
   return (
     <mesh
       ref={ref}
@@ -109,12 +95,7 @@ function Plane({
       onPointerOut={handlePointerOut}
     >
       <planeGeometry args={[10, 10]} />
-      <meshStandardMaterial
-        color={isSelected ? '#00008B' : 'lightgray'}
-        side={DoubleSide}
-        transparent
-        opacity={isSelected ? 0.8 : 1}
-      />
+      <meshStandardMaterial color="lightgray" side={DoubleSide} />
     </mesh>
   )
 }

--- a/src/useObjectInteractions.ts
+++ b/src/useObjectInteractions.ts
@@ -65,6 +65,10 @@ export function useObjectInteractions({
     })
   }
 
+  useEffect(() => {
+    applyHighlight(ref.current, isSelected)
+  }, [isSelected])
+
   const handlePointerDown = (e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation()
     const local = ref.current
@@ -115,7 +119,7 @@ export function useObjectInteractions({
 
   const handlePointerOut = () => {
     if (hovered.current) {
-      applyHighlight(hovered.current, false)
+      applyHighlight(hovered.current, isSelected)
       hovered.current = null
     }
   }


### PR DESCRIPTION
## Summary
- draw outline around selected objects using EdgesGeometry
- keep outlines active while selected even when pointer leaves
- keep object materials constant (no color change) for selected Box and Plane

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b18d442b4832f94e0151a002c32c3